### PR TITLE
[performance] try not to rerender

### DIFF
--- a/src/components/board.js
+++ b/src/components/board.js
@@ -36,8 +36,8 @@ const Board = ({
 
     <div className="col col1">
       <Tableau
-        G={G}
-        ctx={ctx}
+        G={currentPlayer === '0' && (selected || loading) && G}
+        ctx={currentPlayer === '0' && (selected || loading) && ctx}
         player={players[0]}
         action={action}
         moves={moves}
@@ -79,8 +79,8 @@ const Board = ({
 
     <div className="col col4">
       <Tableau
-        G={G}
-        ctx={ctx}
+        G={currentPlayer === '1' && (selected || loading) && G}
+        ctx={currentPlayer === '1' && (selected || loading) && ctx}
         player={players[1]}
         action={action}
         moves={moves}

--- a/src/components/tableau.js
+++ b/src/components/tableau.js
@@ -60,6 +60,8 @@ const Tableau = ({
 }
 
 Tableau.propTypes = {
+  G: PropTypes.any,
+  ctx: PropTypes.any,
   player: PropTypes.any.isRequired,
   moves: PropTypes.any.isRequired,
   shouldShowLoadTile: PropTypes.bool.isRequired,

--- a/src/components/tableauLand.js
+++ b/src/components/tableauLand.js
@@ -142,8 +142,8 @@ const TableauLand = ({
 }
 
 TableauLand.propTypes = {
-  G: PropTypes.object.isRequired,
-  ctx: PropTypes.object.isRequired,
+  G: PropTypes.any,
+  ctx: PropTypes.any,
   children: PropTypes.any,
   flooded: PropTypes.bool,
   style: PropTypes.object,


### PR DESCRIPTION
Noticing that the rerenders are happening a lot more often, I suspect because `G` and `ctx` are prop-drilled down through Tableau. Maybe this will prevent that by only sending the entire state down if absolutely necessary.