### PR TITLE
[infra] fix jsdom environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16242,7 +16242,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
       "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,mjs}"
     ],
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
     "testURL": "http://localhost",
     "transform": {
       "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
testing wasn't working on circle. per fix discussed in https://stackoverflow.com/questions/42418660/react-testing-error-it-looks-like-you-called-mount-without-a-global-documen?noredirect=1&lq=1, this should get things rolling again.